### PR TITLE
Better document Block Status Word fields in verbose usage

### DIFF
--- a/src/idmp1553.c
+++ b/src/idmp1553.c
@@ -693,11 +693,12 @@ void vUsage(void)
     printf("  Time Bus RT T/R SA WC Errs Data...         \n");
     printf("                                             \n");
     printf("Error Bits:                                  \n");
-    printf("  0x01    Word Error                         \n");
+    printf("  0x01    Word Error (Machester|Sync encoding\n");
+    printf("                          |bad bitcnt|parity)\n");
     printf("  0x02    Sync Error                         \n");
     printf("  0x04    Word Count Error                   \n");
     printf("  0x08    Response Timeout                   \n");
-    printf("  0x10    Format Error                       \n");
+    printf("  0x10    Format Error (illegal gap)         \n");
     printf("  0x20    Message Error                      \n");
     printf("  0x80    RT to RT                           \n");
     }


### PR DESCRIPTION
The block status word includes two fields (format error and word error) which are have a less-obvious (format error) meaning or an aggregate meaning (word error).  Thus, when dumping the verbose usage which explains those fields, actually provide the added information to better let readers understand what those bits are actually trying to communicate without having to pull out the specification document.